### PR TITLE
vertexInfo now uses loc instead of x and y

### DIFF
--- a/MergeSharpWebAPI/Controllers/GraphController.cs
+++ b/MergeSharpWebAPI/Controllers/GraphController.cs
@@ -36,16 +36,23 @@ public class GraphController : ControllerBase
     }
 
     [HttpPost("vertices")]
-    public async Task<IActionResult> AddVertex([BindRequired, FromQuery] int key, [BindRequired, FromQuery] double x, [BindRequired, FromQuery] double y, [BindRequired, FromQuery] string type)
+    public async Task<IActionResult> AddVertex([BindRequired, FromQuery] int key, [BindRequired, FromQuery] string loc, [BindRequired, FromQuery] string type)
     {
         if (!ModelState.IsValid)
         {
             return BadRequest();
         }
 
+        string[] position = loc.Split();
+
+        if (position.Length != 2 || !int.TryParse(position[0], out int x) || !int.TryParse(position[1], out int y))
+        {
+            return BadRequest();
+        }
+
         if (myGraphService.AddVertex(key, x, y, type))
         {
-            Console.WriteLine($"Added Vertex {key} ({x},{y}) {type} locally");
+            Console.WriteLine($"Added Vertex {key} ({loc}) {type} locally");
 
             if (connection.State == HubConnectionState.Connected)
             {

--- a/MergeSharpWebAPI/Models/Graph.cs
+++ b/MergeSharpWebAPI/Models/Graph.cs
@@ -67,11 +67,11 @@ public class Graph : CRDT
         }
 
         public readonly Guid guid { get; }
-        public double x { get; set; }
-        public double y { get; set; }
+        public int x { get; set; }
+        public int y { get; set; }
         public readonly Type type { get; }
 
-        public Vertex(Guid guid, double x, double y, Type type)
+        public Vertex(Guid guid, int x, int y, Type type)
         {
             this.guid = guid;
             this.x = x;

--- a/MergeSharpWebAPI/Models/VertexInfo.cs
+++ b/MergeSharpWebAPI/Models/VertexInfo.cs
@@ -7,10 +7,10 @@ namespace MergeSharpWebAPI.Models;
 public class VertexInfoMsg : PropagationMessage
 {
     [JsonInclude]
-    public LWWRegisterMsg<double> xMsg { get; private set; }
+    public LWWRegisterMsg<int> xMsg { get; private set; }
 
     [JsonInclude]
-    public LWWRegisterMsg<double> yMsg { get; private set; }
+    public LWWRegisterMsg<int> yMsg { get; private set; }
 
     [JsonInclude]
     public Graph.Vertex.Type type { get; private set; }
@@ -21,10 +21,10 @@ public class VertexInfoMsg : PropagationMessage
         type = Graph.Vertex.Type.Invalid;
     }
 
-    public VertexInfoMsg(LWWRegister<double> x, LWWRegister<double> y, Graph.Vertex.Type type)
+    public VertexInfoMsg(LWWRegister<int> x, LWWRegister<int> y, Graph.Vertex.Type type)
     {
-        xMsg = (LWWRegisterMsg<double>) x.GetLastSynchronizedUpdate();
-        yMsg = (LWWRegisterMsg<double>) y.GetLastSynchronizedUpdate();
+        xMsg = (LWWRegisterMsg<int>) x.GetLastSynchronizedUpdate();
+        yMsg = (LWWRegisterMsg<int>) y.GetLastSynchronizedUpdate();
         this.type = type;
     }
 
@@ -48,8 +48,8 @@ public class VertexInfoMsg : PropagationMessage
 
 public class VertexInfo : CRDT
 {
-    private readonly LWWRegister<double> _x;
-    private readonly LWWRegister<double> _y;
+    private readonly LWWRegister<int> _x;
+    private readonly LWWRegister<int> _y;
     private Graph.Vertex.Type _type;
 
     public VertexInfo() {
@@ -58,7 +58,7 @@ public class VertexInfo : CRDT
         _type = Graph.Vertex.Type.Invalid;
      }
 
-    public VertexInfo(double x, double y, Graph.Vertex.Type type)
+    public VertexInfo(int x, int y, Graph.Vertex.Type type)
     {
         _x = new(x);
         _y = new(y);

--- a/MergeSharpWebAPI/Services/GraphService.cs
+++ b/MergeSharpWebAPI/Services/GraphService.cs
@@ -23,17 +23,14 @@ public class GraphService
         [JsonInclude]
         public readonly int key;
         [JsonInclude]
-        public readonly double x;
-        [JsonInclude]
-        public readonly double y;
+        public readonly string loc;
         [JsonInclude]
         public readonly string type;
 
         public VertexInfo(int key, double x, double y, Graph.Vertex.Type type)
         {
             this.key = key;
-            this.x = x;
-            this.y = y;
+            this.loc = $"{x} {y}";
             this.type = type.ToString().ToLower();
         }
     }

--- a/MergeSharpWebAPI/Services/GraphService.cs
+++ b/MergeSharpWebAPI/Services/GraphService.cs
@@ -27,7 +27,7 @@ public class GraphService
         [JsonInclude]
         public readonly string type;
 
-        public VertexInfo(int key, double x, double y, Graph.Vertex.Type type)
+        public VertexInfo(int key, int x, int y, Graph.Vertex.Type type)
         {
             this.key = key;
             this.loc = $"{x} {y}";
@@ -69,7 +69,7 @@ public class GraphService
         throw new KeyNotFoundException();
     }
 
-    public bool AddVertex(int key, double x, double y, string stype)
+    public bool AddVertex(int key, int x, int y, string stype)
     {
         if (_keyToVertexMap.ContainsKey(key))
         {


### PR DESCRIPTION
I update the `VertexInfo` for the frontend to now hold `loc` instead of `x` and `y`.

I also change the `AddVertex` endpoint to take in a `loc` param instead of the `x` and `y` in the query string. It does the parsing in the Controller instead of in the Service so I can return the correct http error code to the front end.

Below are some examples of the new endpoint

Here's an example of a successful put:
![image](https://user-images.githubusercontent.com/49335141/222586115-f409eab0-6241-4727-a3ae-0c6e60282012.png)

Conflict:
![image](https://user-images.githubusercontent.com/49335141/222586138-683635fd-7dda-47d9-842d-40680baf8705.png)


bad request because the y in the location is not an int:
![image](https://user-images.githubusercontent.com/49335141/222586203-d2f9aaf9-05ab-4f27-a5ae-eeb409f25659.png)


bad request because the x in the location is not an int:
![image](https://user-images.githubusercontent.com/49335141/222586288-ef8ceb9a-9335-4516-ae8f-1bf1fa30c358.png)


successful get of information from the first put:
![image](https://user-images.githubusercontent.com/49335141/222586405-5f4c0fa3-8ecb-4a64-8ae3-7426b0680f59.png)
