### PR TITLE
Add functionality to get fresh state on new connection

### DIFF
--- a/MergeSharpWebAPI/Program.cs
+++ b/MergeSharpWebAPI/Program.cs
@@ -147,6 +147,7 @@ internal class Program
         {
             Console.WriteLine(JsonConvert.SerializeObject(myLWWSetService.Get(1)));
             await serverConnection.InvokeAsync("SendClientNewState", myLWWSetService.Get(1).LwwSet.GetLastSynchronizedUpdate().Encode(), newConnectionID);
+            // TODO: change to GraphService instead of LWWSetService
 
             // TODO: check this result for errors
         });

--- a/MergeSharpWebAPI/Program.cs
+++ b/MergeSharpWebAPI/Program.cs
@@ -87,48 +87,59 @@ internal class Program
         {
             //Console.WriteLine("Message received: ", byteMsg);
 
-            //Declare TPTPMsg
-            MergeSharp.TPTPGraphMsg tptpgraphMsg = new MergeSharp.TPTPGraphMsg();
-            tptpgraphMsg.Decode(byteMsg);
+            // //Declare TPTPMsg
+            // MergeSharp.TPTPGraphMsg tptpgraphMsg = new MergeSharp.TPTPGraphMsg();
+            // tptpgraphMsg.Decode(byteMsg);
 
-            myTPTPGraphService.MergeTPTPGraphs(1, tptpgraphMsg);
+            // myTPTPGraphService.MergeTPTPGraphs(1, tptpgraphMsg);
 
-            Console.WriteLine("Graphs merged");
+            // Console.WriteLine("Graphs merged");
 
-            //translate TPTPGraph node guids to a <Guid,int> dictionary
-            //clear existing mapping because state has been updated
-            TranslateGuidstoKeys();
+            // //translate TPTPGraph node guids to a <Guid,int> dictionary
+            // //clear existing mapping because state has been updated
+            // TranslateGuidstoKeys();
 
-            //translate dictionary values into list of Node objects
-            var nodeDataArray = TranslateKeystoNodes();
+            // //translate dictionary values into list of Node objects
+            // var nodeDataArray = TranslateKeystoNodes();
 
-            //set uo http client
+            // //set uo http client
+            // using HttpClient client = new();
+            // client.DefaultRequestHeaders.Accept.Clear();
+
+
+            // //serialize list of Node objects
+            // var serializedNodes = JsonConvert.SerializeObject(nodeDataArray);
+            // Console.WriteLine("serialized nodes: " + serializedNodes);
+            // var requestData = new StringContent(serializedNodes, Encoding.UTF8, "application/json");
+            // //send serilized list of node objects to frontend
+            // //TODO: Send updated state to frontend
+            // Console.WriteLine("Sending Put Request for front-end");
+            // var result = await client.PutAsync(
+            //     "https://localhost:7009/TPTPGraph/SendTPTPGraphToFrontEnd", requestData);
+            // Console.WriteLine(result);
             using HttpClient client = new();
             client.DefaultRequestHeaders.Accept.Clear();
-
-
-            //serialize list of Node objects
-            var serializedNodes = JsonConvert.SerializeObject(nodeDataArray);
-            Console.WriteLine("serialized nodes: " + serializedNodes);
-            var requestData = new StringContent(serializedNodes, Encoding.UTF8, "application/json");
-            //send serilized list of node objects to frontend
-            //TODO: Send updated state to frontend
-            Console.WriteLine("Sending Put Request for front-end");
-            var result = await client.PutAsync(
-                "https://localhost:7009/TPTPGraph/SendTPTPGraphToFrontEnd", requestData);
-            Console.WriteLine(result);
-
-            // decodeLWWSetMsgAndMerge(byteMsg);
-            // Console.WriteLine(JsonConvert.SerializeObject(myLWWSetService.Get(1)));
-            // var frontEndLwwSetJson = JsonConvert.SerializeObject(myLWWSetService.Get(1));
-            // var requestDatalwwset = new StringContent(serializedLwwSet, Encoding.UTF8, "application/json");
-            // var result = await client.PutAsync(
-            //     "https://localhost:7009/LWWSet/SendLWWSetToFrontEnd", requestDatalwwset);
+            DecodeLWWSetMsgAndMerge(byteMsg);
+            Console.WriteLine(JsonConvert.SerializeObject(myLWWSetService.Get(1)));
+            var frontEndLwwSetJson = JsonConvert.SerializeObject(myLWWSetService.Get(1));
+            var requestDatalwwset = new StringContent(frontEndLwwSetJson, Encoding.UTF8, "application/json");
+            var resultLww = await client.PutAsync(
+                "https://localhost:7009/LWWSet/SendLWWSetToFrontEnd", requestDatalwwset);
 
             // TODO: check this result for errors
         });
     }
 
+    private static void ConfigureServerConnectionOnSendMessageToNewConnection()
+    {
+        _ = serverConnection.On<string>("SendMessageToNewConnection", async newConnectionID =>
+        {
+            Console.WriteLine(JsonConvert.SerializeObject(myLWWSetService.Get(1)));
+            await serverConnection.InvokeAsync("SendServerCurrentState", myLWWSetService.Get(1).LwwSet.GetLastSynchronizedUpdate().Encode(), newConnectionID);
+            
+            // TODO: check this result for errors
+        });
+    }
     private static async void ConnectToServer()
     {
         while (serverConnection.State == HubConnectionState.Disconnected)
@@ -137,6 +148,7 @@ internal class Program
             {
                 await serverConnection.StartAsync();
                 Console.WriteLine("Connection started");
+                await serverConnection.InvokeAsync("ReceiveFreshState", serverConnection.ConnectionId);
                 await serverConnection.InvokeAsync("SendEncodedMessage", myLWWSetService.Get(1).LwwSet.GetLastSynchronizedUpdate().Encode());
             }
             catch (Exception ex)
@@ -213,6 +225,8 @@ internal class Program
         ConfigureServerConnectionClosed();
 
         ConfigureServerConnectionOnReceiveEncodeMessage();
+
+        ConfigureServerConnectionOnSendMessageToNewConnection();
 
         ConnectToServer();
     }

--- a/MergeSharpWebAPI/Program.cs
+++ b/MergeSharpWebAPI/Program.cs
@@ -146,7 +146,7 @@ internal class Program
         _ = serverConnection.On<string>("SendMessageToNewConnection", async newConnectionID =>
         {
             Console.WriteLine(JsonConvert.SerializeObject(myLWWSetService.Get(1)));
-            await serverConnection.InvokeAsync("SendServerCurrentState", myLWWSetService.Get(1).LwwSet.GetLastSynchronizedUpdate().Encode(), newConnectionID);
+            await serverConnection.InvokeAsync("SendClientNewState", myLWWSetService.Get(1).LwwSet.GetLastSynchronizedUpdate().Encode(), newConnectionID);
 
             // TODO: check this result for errors
         });
@@ -159,7 +159,7 @@ internal class Program
             {
                 await serverConnection.StartAsync();
                 Console.WriteLine("Connection started");
-                await serverConnection.InvokeAsync("ReceiveFreshState", serverConnection.ConnectionId);
+                await serverConnection.InvokeAsync("RequestStateFromServer", serverConnection.ConnectionId);
                 await serverConnection.InvokeAsync("SendEncodedMessage", myLWWSetService.Get(1).LwwSet.GetLastSynchronizedUpdate().Encode());
             }
             catch (Exception ex)

--- a/MergeSharpWebAPI/ServerConnection/Globals.cs
+++ b/MergeSharpWebAPI/ServerConnection/Globals.cs
@@ -27,8 +27,8 @@ public static class Globals
 
     //public static IDMapping = new Dictionary<Guid, int>() { { Guid.NewGuid(), 1}, { Guid.NewGuid(), 2 } };
 
-    // private const string PropagationMessageServer = "https://serverwebapi20230125175127.azurewebsites.net/hubs/propagationmessage";
-    private const string PropagationMessageServer = "https://localhost:7106/hubs/propagationmessage";
+    private const string PropagationMessageServer = "https://serverwebapi20230125175127.azurewebsites.net/hubs/propagationmessage";
+    // private const string PropagationMessageServer = "https://localhost:7106/hubs/propagationmessage";
     // private const string PropagationMessageServer = "http://localhost:5106/hubs/propagationmessage";
 
     public static readonly HubConnection serverConnection = new HubConnectionBuilder().WithUrl(PropagationMessageServer)

--- a/MergeSharpWebAPI/ServerConnection/Globals.cs
+++ b/MergeSharpWebAPI/ServerConnection/Globals.cs
@@ -27,8 +27,8 @@ public static class Globals
 
     //public static IDMapping = new Dictionary<Guid, int>() { { Guid.NewGuid(), 1}, { Guid.NewGuid(), 2 } };
 
-    private const string PropagationMessageServer = "https://serverwebapi20230125175127.azurewebsites.net/hubs/propagationmessage";
-    // private const string PropagationMessageServer = "https://localhost:7106/hubs/propagationmessage";
+    // private const string PropagationMessageServer = "https://serverwebapi20230125175127.azurewebsites.net/hubs/propagationmessage";
+    private const string PropagationMessageServer = "https://localhost:7106/hubs/propagationmessage";
     // private const string PropagationMessageServer = "http://localhost:5106/hubs/propagationmessage";
 
     public static readonly HubConnection serverConnection = new HubConnectionBuilder().WithUrl(PropagationMessageServer)


### PR DESCRIPTION
PR implements how the server handles communication between a new client and an already connected client. The idea is to get the state from the already connected client and send it to the new client to process. Here are the steps:

When the client first starts up, call the `ReceiveFreshState` hub on the server. This will select a client to send a state to the new client.

The server will invoke `SendMessageToNewConnection` on the selected client. This will make the selected client grab its current state and call the `SendServerCurrentState` hub on the server. 

The server will receive this state and invoke `ReceiveEncodedMessage` on the new client for it to process.