### PR TITLE
update private variables on merge

### DIFF
--- a/MergeSharpWebAPI/Models/Graph.cs
+++ b/MergeSharpWebAPI/Models/Graph.cs
@@ -170,8 +170,10 @@ public class Graph : CRDT
         _canilleraGraph.ApplySynchronizedUpdate(received.cGraphMsg);
 
         // _vertexInfo should contain only the vertices now in the graph
-        var currVerticesFuids = LookupVertexGuids();
-        _vertexInfo = _vertexInfo.Where(kv => currVerticesFuids.Contains(kv.Key)).ToDictionary(kv => kv.Key, kv => kv.Value);
+        var currVerticesGuids = LookupVertexGuids();
+
+        _vertexInfo = _vertexInfo.Where(kv => currVerticesGuids.Contains(kv.Key)).ToDictionary(kv => kv.Key, kv => kv.Value);
+
 
         foreach (var kv in received.vertexInfoMsgs)
         {

--- a/MergeSharpWebAPI/Models/Graph.cs
+++ b/MergeSharpWebAPI/Models/Graph.cs
@@ -83,7 +83,9 @@ public class Graph : CRDT
     private readonly CanilleraGraph _canilleraGraph;
     private Dictionary<Guid, VertexInfo> _vertexInfo;
 
-    public IEnumerable<Guid> Vertices => LookupVertices();
+    public IEnumerable<Guid> VertexGuids => LookupVertexGuids();
+
+    public IEnumerable<Vertex> Vertices => LookupVertices();
 
     public Dictionary<Edge, int> Edges => EdgeCounts();
 
@@ -98,7 +100,7 @@ public class Graph : CRDT
     [OperationType(OpType.Update)]
     public virtual bool AddVertex(Vertex v)
     {
-        if (LookupVertices().Contains(v.guid))
+        if (LookupVertexGuids().Contains(v.guid))
         {
             return false;
         }
@@ -132,9 +134,19 @@ public class Graph : CRDT
         return _canilleraGraph.RemoveEdge(new CanilleraGraph.Edge(e.src, e.dst));
     }
 
-    private IEnumerable<Guid> LookupVertices()
+    private IEnumerable<Guid> LookupVertexGuids()
     {
         return _canilleraGraph.LookupVertices();
+    }
+
+    private IEnumerable<Vertex> LookupVertices()
+    {
+        List<Vertex> vertices = new();
+        foreach ((Guid guid, VertexInfo vertexInfo) in _vertexInfo)
+        {
+            vertices.Add(new Vertex(guid, vertexInfo.X, vertexInfo.Y, vertexInfo.Type));
+        }
+        return vertices;
     }
 
     private Dictionary<Edge, int> EdgeCounts()
@@ -158,8 +170,8 @@ public class Graph : CRDT
         _canilleraGraph.ApplySynchronizedUpdate(received.cGraphMsg);
 
         // _vertexInfo should contain only the vertices now in the graph
-        var currVertices = LookupVertices();
-        _vertexInfo = _vertexInfo.Where(kv => currVertices.Contains(kv.Key)).ToDictionary(kv => kv.Key, kv => kv.Value);
+        var currVerticesFuids = LookupVertexGuids();
+        _vertexInfo = _vertexInfo.Where(kv => currVerticesFuids.Contains(kv.Key)).ToDictionary(kv => kv.Key, kv => kv.Value);
 
         foreach (var kv in received.vertexInfoMsgs)
         {

--- a/MergeSharpWebAPI/Models/VertexInfo.cs
+++ b/MergeSharpWebAPI/Models/VertexInfo.cs
@@ -50,19 +50,22 @@ public class VertexInfo : CRDT
 {
     private readonly LWWRegister<int> _x;
     private readonly LWWRegister<int> _y;
-    private Graph.Vertex.Type _type;
+
+    public int X => _x.Value;
+    public int Y => _y.Value;
+    public Graph.Vertex.Type Type { get; private set; }
 
     public VertexInfo() {
         _x = new();
         _y = new();
-        _type = Graph.Vertex.Type.Invalid;
+        Type = Graph.Vertex.Type.Invalid;
      }
 
     public VertexInfo(int x, int y, Graph.Vertex.Type type)
     {
         _x = new(x);
         _y = new(y);
-        _type = type;
+        Type = type;
     }
 
     public override void ApplySynchronizedUpdate(PropagationMessage receivedUpdate)
@@ -76,9 +79,9 @@ public class VertexInfo : CRDT
         _x.ApplySynchronizedUpdate(received.xMsg);
         _y.ApplySynchronizedUpdate(received.yMsg);
 
-        // this should only occur if this._type == Graph.Vertex.Type.Invalid
+        // this should only occur if this.Type == Graph.Vertex.Type.Invalid
         // NOTE: Graph.Vertex.Type.Invalid is the smallest enum
-        _type = _type > received.type ? _type : received.type;
+        Type = Type > received.type ? Type : received.type;
     }
     public override PropagationMessage DecodePropagationMessage(byte[] input)
     {
@@ -87,5 +90,5 @@ public class VertexInfo : CRDT
         return msg;
     }
 
-    public override PropagationMessage GetLastSynchronizedUpdate() => new VertexInfoMsg(this._x, this._y, this._type);
+    public override PropagationMessage GetLastSynchronizedUpdate() => new VertexInfoMsg(this._x, this._y, this.Type);
 }

--- a/MergeSharpWebAPI/Services/GraphService.cs
+++ b/MergeSharpWebAPI/Services/GraphService.cs
@@ -134,21 +134,22 @@ public class GraphService
         return false;
     }
 
-    // TODO: where is this function called / who calls this function? Frontend or backend?
-    // - if frontend then how would they have access to GraphMsg?
-    // public void ApplySynchronizedUpdate(GraphMsg msg) => _graph.ApplySynchronizedUpdate(msg);
-
-    // Change the above to the following:
     public void ApplySynchronizedUpdate(byte[] encodedMsg)
     {
         GraphMsg decodedMsg = new();
         decodedMsg.Decode(encodedMsg);
-        // TODO: This function should return true or false if the merge was successful
-        // encodedMsg may be of wrong type or the message may have been messed up in transit
-        // TODO: or catch the NotSupportedException
         _graph.ApplySynchronizedUpdate(decodedMsg);
 
-        // TODO: update _keyToVertexMap and _vertexGuidToKeyMap
+        _vertexGuidToKeyMap.Clear();
+        _keyToVertexMap.Clear();
+
+        int i = 0;
+        foreach (Graph.Vertex vertex in _graph.Vertices)
+        {
+            _vertexGuidToKeyMap.Add(vertex.guid, i);
+            _keyToVertexMap.Add(i, vertex);
+            i++;
+        }
     }
 
     // return the encoded message because the caller should not know anything about Graph


### PR DESCRIPTION
`ApplySynchronizedUpdate` in the backend now updates the internal maps Vertex <-> key for lookup.

I don't like how VertexInfo is not part of a Vertex in Graph. I'll do some reorg later, but this should work for now